### PR TITLE
Minor change in the JavascriptComputeEngine coalesceFloat method

### DIFF
--- a/src/extensions/compute/JavaScriptComputeEngine.ts
+++ b/src/extensions/compute/JavaScriptComputeEngine.ts
@@ -255,7 +255,7 @@ export class JavaScriptComputeEngine implements ComputeEngine
         {
             if (v !== undefined)
             {
-                return parseFloat(v) || 0;
+                return parseFloat(v.replace(/,/g, '')) || 0;
             }
         }
 


### PR DESCRIPTION
Remove any comma's from the given set of values when computing a formula to avoid parseFloat discarding any trailing zero's after any comma's.  (E.g. parseFloat('10,000) resolves to 10 due to parseFloat ignoring anything after the comma, therefore removing comma's will at least retain the whole value when passing it to parseFloat).  parseFloat only considers +, -, number, exponent or decimal point.